### PR TITLE
Use nozzle_high_flow on high flow filaments instead of printer HF_NOZZLE

### DIFF
--- a/PrusaResearch/2.4.3.ini
+++ b/PrusaResearch/2.4.3.ini
@@ -8761,7 +8761,7 @@ inherits = *PLAXL*; *PA_PLAHF*
 filament_max_volumetric_speed = 21
 filament_infill_max_speed = 0
 filament_infill_max_crossing_speed = 200
-compatible_printers_condition = printer_notes=~/.*XL.*/ and nozzle_diameter[0]!=0.6 and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.5 and printer_notes=~/.*HF_NOZZLE.*/
+compatible_printers_condition = printer_notes=~/.*XL.*/ and nozzle_diameter[0]!=0.6 and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.5 and nozzle_high_flow[0]
 
 [filament:*PLA05HFXL*]
 inherits = *PLAXL*; *PA_PLAHF*
@@ -8769,21 +8769,21 @@ filament_max_volumetric_speed = 24
 slowdown_below_layer_time = 11
 filament_infill_max_speed = 0
 filament_infill_max_crossing_speed = 200
-compatible_printers_condition = printer_notes=~/.*XL.*/ and nozzle_diameter[0]==0.5 and printer_notes=~/.*HF_NOZZLE.*/
+compatible_printers_condition = printer_notes=~/.*XL.*/ and nozzle_diameter[0]==0.5 and nozzle_high_flow[0]
 
 [filament:*PLA06HFXL*]
 inherits = *PLA06XL*; *PA_PLAHF*
 filament_max_volumetric_speed = 30
 filament_infill_max_speed = 0
 filament_infill_max_crossing_speed = 0
-compatible_printers_condition = printer_notes=~/.*XL.*/ and nozzle_diameter[0]==0.6 and printer_notes=~/.*HF_NOZZLE.*/
+compatible_printers_condition = printer_notes=~/.*XL.*/ and nozzle_diameter[0]==0.6 and and nozzle_high_flow[0]
 
 [filament:*PLA08HFXL*]
 inherits = *PLA08XL*; *PA_PLAHF*
 filament_max_volumetric_speed = 35
 filament_infill_max_speed = 0
 filament_infill_max_crossing_speed = 0
-compatible_printers_condition = printer_notes=~/.*XL.*/ and nozzle_diameter[0]==0.8 and printer_notes=~/.*HF_NOZZLE.*/
+compatible_printers_condition = printer_notes=~/.*XL.*/ and nozzle_diameter[0]==0.8 and nozzle_high_flow[0]
 
 [filament:*PET*]
 inherits = *common*


### PR DESCRIPTION
Allow for High flow to be nozzle-bound for filaments rather than printer bound. Allows HF filaments to show up for that nozzle if only one nozzle on the printer is HF